### PR TITLE
Conditionally pass an int to pluralize/singularize

### DIFF
--- a/src/services/TypogrifyService.php
+++ b/src/services/TypogrifyService.php
@@ -110,7 +110,12 @@ class TypogrifyService extends Component
      */
     public function humanFileSize($bytes, $decimals = 1): string
     {
-        return Craft::$app->formatter->asShortSize($bytes, $decimals);
+        $oldSize = Craft::$app->formatter->sizeFormatBase;
+        Craft::$app->formatter->sizeFormatBase = 1000;
+        $result = Craft::$app->formatter->asShortSize($bytes, $decimals);
+        Craft::$app->formatter->sizeFormatBase = $oldSize;
+
+        return $result;
     }
 
     /**

--- a/src/services/TypogrifyService.php
+++ b/src/services/TypogrifyService.php
@@ -179,12 +179,13 @@ class TypogrifyService extends Component
      * For example, 'apple' will become 'apples', and 'child' will become 'children'
      *
      * @param string $word
+     * @param int    $number
      *
      * @return string
      */
-    public function pluralize(string $word): string
+    public function pluralize(string $word, int $number = 2): string
     {
-        return Inflector::pluralize($word);
+        return abs($number) === 1 ? $word : Inflector::pluralize($word);
     }
 
     /**
@@ -192,12 +193,13 @@ class TypogrifyService extends Component
      * For example, 'apples' will become 'apple', and 'children' will become 'child'
      *
      * @param string $word
+     * @param int    $number
      *
      * @return string
      */
-    public function singularize(string $word): string
+    public function singularize(string $word, int $number = 1): string
     {
-        return Inflector::singularize($word);
+        return abs($number) === 1 ? Inflector::pluralize($word) : $word;
     }
 
     /**

--- a/src/twigextensions/TypogrifyTwigExtension.php
+++ b/src/twigextensions/TypogrifyTwigExtension.php
@@ -182,12 +182,13 @@ class TypogrifyTwigExtension extends \Twig_Extension
      * For example, 'apple' will become 'apples', and 'child' will become 'children'
      *
      * @param string $word
+     * @param int    $number
      *
      * @return \Twig_Markup
      */
-    public function pluralize(string $word)
+    public function pluralize(string $word, int $number = 2)
     {
-        return Template::raw(Typogrify::$plugin->typogrify->pluralize($word));
+        return Template::raw(Typogrify::$plugin->typogrify->pluralize($word, $number));
     }
 
     /**
@@ -195,12 +196,13 @@ class TypogrifyTwigExtension extends \Twig_Extension
      * For example, 'apples' will become 'apple', and 'children' will become 'child'
      *
      * @param string $word
+     * @param int    $number
      *
      * @return \Twig_Markup
      */
-    public function singularize(string $word)
+    public function singularize(string $word, int $number = 1)
     {
-        return Template::raw(Typogrify::$plugin->typogrify->singularize($word));
+        return Template::raw(Typogrify::$plugin->typogrify->singularize($word, $number));
     }
 
     /**


### PR DESCRIPTION
Makes these inflector methods way more useful, especially in a templating context, e.g.:

```
{{ cart.totalQty }} {{ 'item'|pluralize(cart.totalQty) }} in your cart
```