### PR TITLE
Adds $set_dewidow_word_number to settings

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -168,6 +168,9 @@ return [
     // establishes maximum length of a widows that will be protected
     "set_max_dewidow_length" => 5,
 
+    // establishes the maximum number of words considered for dewidowing.
+    "set_dewidow_word_number" => 1,
+
     // establishes maximum length of pulled text to keep widows company
     "set_max_dewidow_pull" => 5,
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -277,6 +277,13 @@ class Settings extends Model
     public $set_max_dewidow_length = 5;
 
     /**
+     * establishes the maximum number of words considered for dewidowing.
+     *
+     * @var int
+     */
+    public $set_dewidow_word_number = 1;
+
+    /**
      * establishes maximum length of pulled text to keep widows company
      *
      * @var int
@@ -459,6 +466,7 @@ class Settings extends Model
             [
                 [
                     'set_max_dewidow_length',
+                    'set_dewidow_word_number',
                     'set_max_dewidow_pull',
                     'set_min_after_url_wrap',
                     'set_min_length_hyphenation',


### PR DESCRIPTION
Adds the ability to set the the maximum number of words considered for dewidowing via the plugin’s config file which allows you to specify whether you'd like to have a one, two, or three word minimum on the final line.

This is an enhancement that was [added to php-typography](https://github.com/mundschenk-at/php-typography/issues/4) a while back and this pull request allows it to be configured via the plugin’s settings to avoid having to override it in each template where the filter is used (i.e. `{% do phpTypographySettings.set_dewidow_word_number(3) %}`)
