### PR TITLE
Allow for escaping inputs by default

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -26,6 +26,9 @@ use \PHP_Typography\Settings\Quote_Style;
  */
 
 return [
+    // sets whether input should be escaped by default
+    "default_escape" => false,
+
     // sets tags where typography of children will be untouched
     "set_tags_to_ignore" => [
         "code",

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,6 +27,13 @@ class Settings extends Model
     // =========================================================================
 
     /**
+     * sets whether input should be escaped by default
+     *
+     * @var boolean
+     */
+    public $default_escape = false;
+
+    /**
      * sets tags where typography of children will be untouched
      *
      * @var array

--- a/src/services/TypogrifyService.php
+++ b/src/services/TypogrifyService.php
@@ -63,7 +63,9 @@ class TypogrifyService extends Component
         if ($settings !== false) {
             $settingsArray = $settings->toArray();
             foreach ($settingsArray as $key => $value) {
-                $this->phpTypographySettings->{$key}($value);
+                if ($key !== 'default_escape') {
+                    $this->phpTypographySettings->{$key}($value);
+                }
             }
         }
     }

--- a/src/variables/TypogrifyVariable.php
+++ b/src/variables/TypogrifyVariable.php
@@ -303,6 +303,13 @@ class TypogrifyVariable
         }
         $text = (string)$text;
 
+        $settings = Typogrify::$plugin->getSettings();
+
+        if ($settings['default_escape'] === true) {
+            $twig = Craft::$app->view->twig;
+            $text = twig_escape_filter($twig, $text);
+        }
+
         return $text;
     }
 }


### PR DESCRIPTION
This adds a `default_escape` config setting which can be used to toggle whether or not escaping is enabled by default. This allows for a safer default behaviour and avoids the need to chain multiple `|escape|typogrify` filters everywhere.

I haven’t changed the current default, so escaping is still off unless you override the setting in your local config.