### PR TITLE
Fix #29 (wordLimit turns "à" into replacement character)

### DIFF
--- a/src/services/TypogrifyService.php
+++ b/src/services/TypogrifyService.php
@@ -371,7 +371,7 @@ class TypogrifyService extends Component
      */
     public function wordLimit(string $string, int $length, string $substring = '…'): string
     {
-        $words = preg_split("/[\s]+/", strip_tags($string));
+        $words = preg_split("/[\s]+/u", strip_tags($string));
         $result = implode(' ', array_slice($words, 0, $length));
 
         return count($words) > $length ? $result.$substring : $result;


### PR DESCRIPTION
The `u` modifier makes the regex engine treat the input as a Unicode string, which fixes the issue for some reason.