### PR TITLE
Allow passing empty values

### DIFF
--- a/src/services/TypogrifyService.php
+++ b/src/services/TypogrifyService.php
@@ -74,19 +74,19 @@ class TypogrifyService extends Component
      * Typogrify applies a veritable kitchen sink of typographic treatments to
      * beautify your web typography
      *
-     * @param string $text The text or HTML fragment to process
+     * @param string|int|float|null $text The text or HTML fragment to process
      * @param bool $isTitle Optional. If the HTML fragment is a title.
      *                        Default false
      *
      * @return string The processed HTML
      */
-    public function typogrify(string $text, bool $isTitle = false): string
+    public function typogrify(string|int|float|null $text, bool $isTitle = false): string
     {
         if (empty($text)) {
             return '';
         }
 
-        return $this->phpTypography->process($text, $this->phpTypographySettings, $isTitle);
+        return $this->phpTypography->process((string) $text, $this->phpTypographySettings, $isTitle);
     }
 
     /**
@@ -95,33 +95,33 @@ class TypogrifyService extends Component
      * (or similar) feeds -- i.e. excluding processes that may cause issues in
      * contexts with limited character set intelligence.
      *
-     * @param string $text The text or HTML fragment to process
+     * @param string|int|float|null $text The text or HTML fragment to process
      * @param bool $isTitle Optional. If the HTML fragment is a title.
      *                        Default false
      *
      * @return string The processed HTML
      */
-    public function typogrifyFeed(string $text, bool $isTitle = false): string
+    public function typogrifyFeed(string|int|float|null $text, bool $isTitle = false): string
     {
         if (empty($text)) {
             return '';
         }
 
-        return $this->phpTypography->process_feed($text, $this->phpTypographySettings, $isTitle);
+        return $this->phpTypography->process_feed((string) $text, $this->phpTypographySettings, $isTitle);
     }
 
     /**
-     * @param string $text
+     * @param string|int|float|null $text
      *
      * @return string
      */
-    public function smartypants(string $text): string
+    public function smartypants(string|int|float|null $text): string
     {
         if (empty($text)) {
             return '';
         }
 
-        return SmartyPants::defaultTransform($text);
+        return SmartyPants::defaultTransform((string) $text);
     }
 
     /**
@@ -129,13 +129,13 @@ class TypogrifyService extends Component
      * truncating occurs, the string is further truncated so that the substring
      * may be appended without exceeding the desired length.
      *
-     * @param string $string The string to truncate
+     * @param string|int|float|null $string The string to truncate
      * @param int $length Desired length of the truncated string
      * @param string $substring The substring to append if it can fit
      *
      * @return string with the resulting $str after truncating
      */
-    public function truncate(string $string, int $length, string $substring = '…'): string
+    public function truncate(string|int|float|null $string, int $length, string $substring = '…'): string
     {
         $result = $string;
 
@@ -153,13 +153,13 @@ class TypogrifyService extends Component
      * string is further truncated so that the substring may be appended without
      * exceeding the desired length.
      *
-     * @param string $string The string to truncate
+     * @param string|int|float|null $string The string to truncate
      * @param int $length Desired length of the truncated string
      * @param string $substring The substring to append if it can fit
      *
      * @return string with the resulting $str after truncating
      */
-    public function truncateOnWord(string $string, int $length, string $substring = '…'): string
+    public function truncateOnWord(string|int|float|null $string, int $length, string $substring = '…'): string
     {
         $result = $string;
 
@@ -179,12 +179,12 @@ class TypogrifyService extends Component
      * then returns the initialized object. Throws an InvalidArgumentException
      * if the first argument is an array or object without a __toString method.
      *
-     * @param string $string The string initialize the Stringy object with
+     * @param string|int|float|null $string The string initialize the Stringy object with
      * @param null|string $encoding The character encoding
      *
      * @return Stringy
      */
-    public function stringy(string $string = '', ?string $encoding = null): Stringy
+    public function stringy(string|int|float|null $string = '', ?string $encoding = null): Stringy
     {
         return Stringy::create($string, $encoding);
     }

--- a/src/variables/TypogrifyVariable.php
+++ b/src/variables/TypogrifyVariable.php
@@ -33,13 +33,13 @@ class TypogrifyVariable
      * Typogrify applies a veritable kitchen sink of typographic treatments to
      * beautify your web typography
      *
-     * @param string $text The text or HTML fragment to process
+     * @param string|int|float|null $text The text or HTML fragment to process
      * @param bool $isTitle Optional. If the HTML fragment is a title.
      *                        Default false
      *
      * @return Markup
      */
-    public function typogrify(string $text, bool $isTitle = false): Markup
+    public function typogrify(string|int|float|null $text, bool $isTitle = false): Markup
     {
         $text = $this->normalizeText($text);
         return Template::raw(Typogrify::$plugin->typogrify->typogrify($text, $isTitle));
@@ -51,24 +51,24 @@ class TypogrifyVariable
      * (or similar) feeds -- i.e. excluding processes that may cause issues in
      * contexts with limited character set intelligence.
      *
-     * @param string $text The text or HTML fragment to process
+     * @param string|int|float|null $text The text or HTML fragment to process
      * @param bool $isTitle Optional. If the HTML fragment is a title.
      *                        Default false
      *
      * @return Markup
      */
-    public function typogrifyFeed(string $text, bool $isTitle = false): Markup
+    public function typogrifyFeed(string|int|float|null $text, bool $isTitle = false): Markup
     {
         $text = $this->normalizeText($text);
         return Template::raw(Typogrify::$plugin->typogrify->typogrifyFeed($text, $isTitle));
     }
 
     /**
-     * @param string $text
+     * @param string|int|float|null $text
      *
      * @return Markup
      */
-    public function smartypants(string $text): Markup
+    public function smartypants(string|int|float|null $text): Markup
     {
         $text = $this->normalizeText($text);
         return Template::raw(Typogrify::$plugin->typogrify->smartypants($text));
@@ -87,13 +87,13 @@ class TypogrifyVariable
      * truncating occurs, the string is further truncated so that the substring
      * may be appended without exceeding the desired length.
      *
-     * @param string $string The string to truncate
+     * @param string|int|float|null $string The string to truncate
      * @param int $length Desired length of the truncated string
      * @param string $substring The substring to append if it can fit
      *
      * @return string with the resulting $str after truncating
      */
-    public function truncate(string $string, int $length, string $substring = '…'): string
+    public function truncate(string|int|float|null $string, int $length, string $substring = '…'): string
     {
         return Typogrify::$plugin->typogrify->truncate($string, $length, $substring);
     }
@@ -104,13 +104,13 @@ class TypogrifyVariable
      * string is further truncated so that the substring may be appended without
      * exceeding the desired length.
      *
-     * @param string $string The string to truncate
+     * @param string|int|float|null $string The string to truncate
      * @param int $length Desired length of the truncated string
      * @param string $substring The substring to append if it can fit
      *
      * @return string with the resulting $str after truncating
      */
-    public function truncateOnWord(string $string, int $length, string $substring = '…'): string
+    public function truncateOnWord(string|int|float|null $string, int $length, string $substring = '…'): string
     {
         return Typogrify::$plugin->typogrify->truncateOnWord($string, $length, $substring);
     }
@@ -122,12 +122,12 @@ class TypogrifyVariable
      * then returns the initialized object. Throws an InvalidArgumentException
      * if the first argument is an array or object without a __toString method.
      *
-     * @param string $string The string initialize the Stringy object with
+     * @param string|int|float|null $string The string initialize the Stringy object with
      * @param null|string $encoding The character encoding
      *
      * @return Stringy
      */
-    public function stringy(string $string = '', ?string $encoding = null): Stringy
+    public function stringy(string|int|float|null $string = '', ?string $encoding = null): Stringy
     {
         return Typogrify::$plugin->typogrify->stringy($string, $encoding);
     }


### PR DESCRIPTION
### Description
I extended the allowed types from `string` to `string|int|float|null` in all places where there was no type hint in v1. (In fact there were type hints in the doc blocks. But they didn't lead to TypeErrors.)

I don't think using the `mixed` type here is appropriate because it also includes `object|resource|array|bool` which makes no sense for Typogrify.

Anything that I am missing here?

Oh, and I also explicitly cast values to string if they pass the empty test so that no `int|float` gets passed to the underlying packages.

### Related issues
#72 